### PR TITLE
Add graphql as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@as-integration/aws-lambda",
-  "version": "0.0.0",
+  "name": "@as-integrations/aws-lambda",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@as-integration/aws-lambda",
-      "version": "0.0.0",
+      "name": "@as-integrations/aws-lambda",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -31,7 +31,8 @@
         "node": ">=14.0"
       },
       "peerDependencies": {
-        "@apollo/server": "^4.0.0-alpha.10"
+        "@apollo/server": "^4.0.0-alpha.10",
+        "graphql": "^16.6.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "typescript": "4.8.2"
   },
   "peerDependencies": {
-    "@apollo/server": "^4.0.0-alpha.10"
+    "@apollo/server": "^4.0.0-alpha.10",
+    "graphql": "^16.6.0"
   },
   "volta": {
     "node": "16.17.0",


### PR DESCRIPTION
Library packages such as this need to include `graphql` as a peer dependency.

This is because it _should not_ be specified as a standard runtime dependency by our library, but it does still depend on it.

The details for why it shouldn't be a runtime dependency are explained here:
https://leebyron.com/graphql-js-preparing-for-v14/

Note that going forward, changes that _narrow_ the version of this peer are considered breaking changes and warrant a major version bump.

For example:

_Expanding_ the peer dependency range is not breaking. We are adding additional support for users.
```
"graphql": "^16.6.0 || ^17.0.0"
```
This says we now claim support for 16.6+ _and_ 17.

If we were then to drop 16:
```
"graphql": "^17.0.0"
```
...this would be a breaking change for users since those on v16.x would now have invalid installs.