### PR TITLE
Run build script with `npx`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "node": ">=14.0"
   },
   "scripts": {
-    "build": "tsc --build tsconfig.build.json",
+    "//": "#use npx here to ensure that non-TS users triggering the postinstall script don't need to install TypeScript globally or in their project",
+    "build": "npx -p typescript tsc --build tsconfig.build.json",
     "clean": "git clean -dfqX",
     "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i",
     "postinstall": "npm run build",


### PR DESCRIPTION
Copied from https://github.com/apollographql/typescript-repo-template/pull/83

> When this template is used to create and publish a typescript package, it creates a problem for projects which don't install typescript as a dev dependency.
>
> The problem is that postinstall is run when this is added to a project, which runs tsc. For JS users who don't have Typescript installed as a dev dependency or globally, this will unsurprisingly result in the error:
sh: tsc: command not found
>
> Using npx here to run tsc will install typescript to a local cache if needed, and default to using it from node_modules/.bin when it exists, so this should be a no-op for typescript users and a major improvement for non-TS users.

Alternatively, removing the `postinstall` script is an option, but it's not my preference.