### PR TITLE
Fix recognition of API Gateway V1 events

### DIFF
--- a/.changeset/serious-fishes-act.md
+++ b/.changeset/serious-fishes-act.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/aws-lambda': patch
+---
+
+Correctly recognize gateway v1 events

--- a/src/__tests__/mockAPIGatewayV1Server.ts
+++ b/src/__tests__/mockAPIGatewayV1Server.ts
@@ -30,6 +30,8 @@ function v1EventFromRequest(
 
   // simplify the V1 event down to what our integration actually cares about
   const event: Partial<APIGatewayProxyEvent> = {
+    // @ts-expect-error (version actually can exist on v1 events, this seems to be a typing error)
+    version: "1.0",
     httpMethod: req.method!,
     headers: Object.fromEntries(
       Object.entries(req.headers).map(([name, value]) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,11 @@ function normalizeGatewayEvent(event: GatewayEvent): HTTPGraphQLRequest {
 }
 
 function isV1Event(event: GatewayEvent): event is APIGatewayProxyEvent {
-  return !('version' in event);
+  // APIGatewayProxyEvent incorrectly omits `version` even though API Gateway v1
+  // events may include `version: "1.0"`
+  return (
+    !('version' in event) || ('version' in event && event.version === '1.0')
+  );
 }
 
 function isV2Event(event: GatewayEvent): event is APIGatewayProxyEventV2 {


### PR DESCRIPTION
Fixes #29. The package `@types/aws-lambda` seems to incorrectly omit the `version` property from `APIGatewayProxyEvent`. As shown in the [AWS docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html), API Gateway V1 events do indeed contain a `version` property set to `"1.0"`.

Until the typing omission is confirmed as a bug, I am leaving the `!('version' in event)` condition in case that is a potential scenario.