### PR TITLE
Support capitalized Content-Type header

### DIFF
--- a/.changeset/polite-goats-taste.md
+++ b/.changeset/polite-goats-taste.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/aws-lambda': patch
+---
+
+Downcase all header keys during normalization

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,10 +111,7 @@ function isV2Event(event: GatewayEvent): event is APIGatewayProxyEventV2 {
 
 function normalizeV1Event(event: APIGatewayProxyEvent): HTTPGraphQLRequest {
   const headers = normalizeHeaders(event.headers);
-  const body = parseBody(
-    event.body,
-    headers.get('content-type') ?? headers.get('Content-Type'),
-  );
+  const body = parseBody(event.body, headers.get('content-type'));
   // Single value parameters can be directly added
   const searchParams = new URLSearchParams(
     normalizeQueryStringParams(event.queryStringParameters),
@@ -144,10 +141,7 @@ function normalizeV2Event(event: APIGatewayProxyEventV2): HTTPGraphQLRequest {
     method: event.requestContext.http.method,
     headers,
     search: event.rawQueryString,
-    body: parseBody(
-      event.body,
-      headers.get('content-type') ?? headers.get('Content-Type'),
-    ),
+    body: parseBody(event.body, headers.get('content-type')),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ function normalizeHeaders(
 ): Map<string, string> {
   const headerMap = new Map<string, string>();
   for (const [key, value] of Object.entries(headers)) {
-    headerMap.set(key, value ?? '');
+    headerMap.set(key.toLocaleLowerCase(), value ?? '');
   }
   return headerMap;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,10 @@ function isV2Event(event: GatewayEvent): event is APIGatewayProxyEventV2 {
 
 function normalizeV1Event(event: APIGatewayProxyEvent): HTTPGraphQLRequest {
   const headers = normalizeHeaders(event.headers);
-  const body = parseBody(event.body, headers.get('content-type'));
+  const body = parseBody(
+    event.body,
+    headers.get('content-type') ?? headers.get('Content-Type'),
+  );
   // Single value parameters can be directly added
   const searchParams = new URLSearchParams(
     normalizeQueryStringParams(event.queryStringParameters),
@@ -141,7 +144,10 @@ function normalizeV2Event(event: APIGatewayProxyEventV2): HTTPGraphQLRequest {
     method: event.requestContext.http.method,
     headers,
     search: event.rawQueryString,
-    body: parseBody(event.body, headers.get('content-type')),
+    body: parseBody(
+      event.body,
+      headers.get('content-type') ?? headers.get('Content-Type'),
+    ),
   };
 }
 


### PR DESCRIPTION
Incoming request headers are inspected to determine how to parse the request body. Currently, this inspection uses `headers.get('content-type')`, which returns `undefined` if the header key is capitalized (i.e., `Content-Type`). This falls back to checking for the capitalized header if the lowercase one is not found.

Fixes #31.