### PR TITLE
Updated header integration to use HeaderMap from @apollo/server

### DIFF
--- a/.changeset/green-zoos-agree.md
+++ b/.changeset/green-zoos-agree.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/aws-lambda': patch
+---
+
+Updated headers to HeaderMap implementation for case normalization

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import type {
   ContextFunction,
   HTTPGraphQLRequest,
 } from '@apollo/server';
+import { HeaderMap } from '@apollo/server';
 import type { WithRequired } from '@apollo/utils.withrequired';
 import type {
   APIGatewayProxyEvent,
@@ -164,12 +165,10 @@ function parseBody(
   return '';
 }
 
-function normalizeHeaders(
-  headers: APIGatewayProxyEventHeaders,
-): Map<string, string> {
-  const headerMap = new Map<string, string>();
+function normalizeHeaders(headers: APIGatewayProxyEventHeaders): HeaderMap {
+  const headerMap = new HeaderMap();
   for (const [key, value] of Object.entries(headers)) {
-    headerMap.set(key.toLocaleLowerCase(), value ?? '');
+    headerMap.set(key, value ?? '');
   }
   return headerMap;
 }


### PR DESCRIPTION
Updates the `Map<string, string>` to `HeaderMap`. The `HeaderMap` type is a superset of `Map<string, string>` where keys are all lowercased (for all methods:  `set`, `get`, `has`, and `delete`).

When observing the `HTTPGraphQLRequest` type, headers is expected to be of type `HeaderMap`. Typescript overlooked this and didn't complain because from a type perspective `Map<string, string>` and `HeaderMap` 100% overlap, but in functionality `HeaderMap` manages case normalization too.

For the sake of consistency with the requested type by `@apollo/server` this PR implements `HeaderMap`

Somewhat supersedes #32