### PR TITLE
Added support for ALB event type

### DIFF
--- a/.changeset/blue-baboons-attend.md
+++ b/.changeset/blue-baboons-attend.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/aws-lambda': minor
+---
+
+ALB Event type integration

--- a/.changeset/shaggy-moose-own.md
+++ b/.changeset/shaggy-moose-own.md
@@ -1,5 +1,0 @@
----
-'@as-integrations/aws-lambda': patch
----
-
-ALB event type integration and parsing

--- a/.changeset/shaggy-moose-own.md
+++ b/.changeset/shaggy-moose-own.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/aws-lambda': patch
+---
+
+ALB event type integration and parsing

--- a/src/__tests__/integrationALB.test.ts
+++ b/src/__tests__/integrationALB.test.ts
@@ -1,0 +1,47 @@
+import { ApolloServer, ApolloServerOptions, BaseContext } from '@apollo/server';
+import {
+  CreateServerForIntegrationTestsOptions,
+  defineIntegrationTestSuite,
+} from '@apollo/server-integration-testsuite';
+import { createServer } from 'http';
+import { startServerAndCreateLambdaHandler } from '..';
+import { createMockALBServer } from './mockALBServer';
+import { urlForHttpServer } from './mockServer';
+
+describe('lambdaHandlerALB', () => {
+  defineIntegrationTestSuite(
+    async function (
+      serverOptions: ApolloServerOptions<BaseContext>,
+      testOptions?: CreateServerForIntegrationTestsOptions,
+    ) {
+      const httpServer = createServer();
+      const server = new ApolloServer({
+        ...serverOptions,
+      });
+
+      const handler = testOptions
+        ? startServerAndCreateLambdaHandler(server, testOptions)
+        : startServerAndCreateLambdaHandler(server);
+
+      httpServer.addListener('request', createMockALBServer(handler));
+
+      await new Promise<void>((resolve) => {
+        httpServer.listen({ port: 0 }, resolve);
+      });
+
+      return {
+        server,
+        url: urlForHttpServer(httpServer),
+        async extraCleanup() {
+          await new Promise<void>((resolve) => {
+            httpServer.close(() => resolve());
+          });
+        },
+      };
+    },
+    {
+      serverIsStartedInBackground: true,
+      noIncrementalDelivery: true,
+    },
+  );
+});

--- a/src/__tests__/integrationALB.test.ts
+++ b/src/__tests__/integrationALB.test.ts
@@ -3,6 +3,7 @@ import {
   CreateServerForIntegrationTestsOptions,
   defineIntegrationTestSuite,
 } from '@apollo/server-integration-testsuite';
+import type { ALBEvent, ALBResult, Handler } from 'aws-lambda';
 import { createServer } from 'http';
 import { startServerAndCreateLambdaHandler } from '..';
 import { createMockALBServer } from './mockALBServer';
@@ -23,7 +24,10 @@ describe('lambdaHandlerALB', () => {
         ? startServerAndCreateLambdaHandler(server, testOptions)
         : startServerAndCreateLambdaHandler(server);
 
-      httpServer.addListener('request', createMockALBServer(handler));
+      httpServer.addListener(
+        'request',
+        createMockALBServer(handler as Handler<ALBEvent, ALBResult>),
+      );
 
       await new Promise<void>((resolve) => {
         httpServer.listen({ port: 0 }, resolve);

--- a/src/__tests__/mockServer.ts
+++ b/src/__tests__/mockServer.ts
@@ -8,9 +8,9 @@ import type {
 } from 'aws-lambda';
 import { format } from 'url';
 import type { AddressInfo } from 'net';
-import type { GatewayEvent } from '..';
+import type { IncomingEvent } from '..';
 
-type LambdaHandler<T = GatewayEvent> = Handler<
+type LambdaHandler<T = IncomingEvent> = Handler<
   T,
   T extends APIGatewayProxyEvent
     ? APIGatewayProxyResult
@@ -18,7 +18,7 @@ type LambdaHandler<T = GatewayEvent> = Handler<
 >;
 
 // Returns a Node http handler that invokes a Lambda handler (v1 / v2)
-export function createMockServer<T extends GatewayEvent>(
+export function createMockServer<T extends IncomingEvent>(
   handler: LambdaHandler<T>,
   eventFromRequest: (req: IncomingMessage, body: string) => T,
 ) {

--- a/src/__tests__/mockServer.ts
+++ b/src/__tests__/mockServer.ts
@@ -1,6 +1,8 @@
 import type { IncomingMessage, Server, ServerResponse } from 'http';
 import type {
+  ALBResult,
   APIGatewayProxyEvent,
+  APIGatewayProxyEventV2,
   APIGatewayProxyResult,
   APIGatewayProxyStructuredResultV2,
   Context as LambdaContext,
@@ -14,7 +16,9 @@ type LambdaHandler<T = IncomingEvent> = Handler<
   T,
   T extends APIGatewayProxyEvent
     ? APIGatewayProxyResult
-    : APIGatewayProxyStructuredResultV2
+    : T extends APIGatewayProxyEventV2
+    ? APIGatewayProxyStructuredResultV2
+    : ALBResult
 >;
 
 // Returns a Node http handler that invokes a Lambda handler (v1 / v2)

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,11 @@ export type IncomingEvent =
   | APIGatewayProxyEventV2
   | ALBEvent;
 
+/**
+ * @deprecated Use {IncomingEvent} instead
+ */
+export type GatewayEvent = IncomingEvent;
+
 export interface LambdaContextFunctionArgument {
   event: IncomingEvent;
   context: Context;
@@ -70,7 +75,7 @@ export function startServerAndCreateLambdaHandler<TContext extends BaseContext>(
 
   return async function (event, context) {
     try {
-      const normalizedEvent = normalizeGatewayEvent(event);
+      const normalizedEvent = normalizeIncomingEvent(event);
 
       const { body, headers, status } = await server.executeHTTPGraphQLRequest({
         httpGraphQLRequest: normalizedEvent,
@@ -98,7 +103,7 @@ export function startServerAndCreateLambdaHandler<TContext extends BaseContext>(
   };
 }
 
-function normalizeGatewayEvent(event: IncomingEvent): HTTPGraphQLRequest {
+function normalizeIncomingEvent(event: IncomingEvent): HTTPGraphQLRequest {
   let httpMethod: string;
   if ('httpMethod' in event) {
     httpMethod = event.httpMethod;
@@ -110,7 +115,6 @@ function normalizeGatewayEvent(event: IncomingEvent): HTTPGraphQLRequest {
   if ('rawQueryString' in event) {
     search = event.rawQueryString;
   } else if ('queryStringParameters' in event) {
-    event.queryStringParameters;
     search = normalizeQueryStringParams(
       event.queryStringParameters,
       event.multiValueQueryStringParameters,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export type IncomingEvent =
   | APIGatewayProxyEventV2
   | ALBEvent;
 
+export type GatewayEvent = IncomingEvent;
+
 export interface LambdaContextFunctionArgument {
   event: IncomingEvent;
   context: Context;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export interface LambdaHandlerOptions<TContext extends BaseContext> {
   context?: ContextFunction<[LambdaContextFunctionArgument], TContext>;
 }
 
-type LambdaHandlerResult = (
+export type HandlerResult = (
   | APIGatewayProxyStructuredResultV2
   | APIGatewayProxyResult
   | ALBResult
@@ -39,7 +39,7 @@ type LambdaHandlerResult = (
   statusCode: number;
 };
 
-type LambdaHandler = Handler<IncomingEvent, LambdaHandlerResult>;
+type LambdaHandler = Handler<IncomingEvent, HandlerResult>;
 
 export function startServerAndCreateLambdaHandler(
   server: ApolloServer<BaseContext>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,9 @@ import type {
 import { HeaderMap } from '@apollo/server';
 import type { WithRequired } from '@apollo/utils.withrequired';
 import type {
+  ALBEvent,
+  ALBResult,
   APIGatewayProxyEvent,
-  APIGatewayProxyEventHeaders,
-  APIGatewayProxyEventQueryStringParameters,
   APIGatewayProxyEventV2,
   APIGatewayProxyResult,
   APIGatewayProxyStructuredResultV2,
@@ -17,10 +17,13 @@ import type {
   Handler,
 } from 'aws-lambda';
 
-export type GatewayEvent = APIGatewayProxyEvent | APIGatewayProxyEventV2;
+export type IncomingEvent =
+  | APIGatewayProxyEvent
+  | APIGatewayProxyEventV2
+  | ALBEvent;
 
 export interface LambdaContextFunctionArgument {
-  event: GatewayEvent;
+  event: IncomingEvent;
   context: Context;
 }
 
@@ -28,10 +31,15 @@ export interface LambdaHandlerOptions<TContext extends BaseContext> {
   context?: ContextFunction<[LambdaContextFunctionArgument], TContext>;
 }
 
-type LambdaHandler = Handler<
-  GatewayEvent,
-  APIGatewayProxyStructuredResultV2 | APIGatewayProxyResult
->;
+type LambdaHandlerResult = (
+  | APIGatewayProxyStructuredResultV2
+  | APIGatewayProxyResult
+  | ALBResult
+) & {
+  statusCode: number;
+};
+
+type LambdaHandler = Handler<IncomingEvent, LambdaHandlerResult>;
 
 export function startServerAndCreateLambdaHandler(
   server: ApolloServer<BaseContext>,
@@ -90,63 +98,34 @@ export function startServerAndCreateLambdaHandler<TContext extends BaseContext>(
   };
 }
 
-function normalizeGatewayEvent(event: GatewayEvent): HTTPGraphQLRequest {
-  if (isV1Event(event)) {
-    return normalizeV1Event(event);
+function normalizeGatewayEvent(event: IncomingEvent): HTTPGraphQLRequest {
+  let httpMethod: string;
+  if ('httpMethod' in event) {
+    httpMethod = event.httpMethod;
+  } else {
+    httpMethod = event.requestContext.http.method;
   }
-
-  if (isV2Event(event)) {
-    return normalizeV2Event(event);
-  }
-
-  throw Error('Unknown event type');
-}
-
-function isV1Event(event: GatewayEvent): event is APIGatewayProxyEvent {
-  // APIGatewayProxyEvent incorrectly omits `version` even though API Gateway v1
-  // events may include `version: "1.0"`
-  return (
-    !('version' in event) || ('version' in event && event.version === '1.0')
-  );
-}
-
-function isV2Event(event: GatewayEvent): event is APIGatewayProxyEventV2 {
-  return 'version' in event && event.version === '2.0';
-}
-
-function normalizeV1Event(event: APIGatewayProxyEvent): HTTPGraphQLRequest {
   const headers = normalizeHeaders(event.headers);
-  const body = parseBody(event.body, headers.get('content-type'));
-  // Single value parameters can be directly added
-  const searchParams = new URLSearchParams(
-    normalizeQueryStringParams(event.queryStringParameters),
-  );
-  // Passing a key with an array entry to the constructor yields
-  // one value in the querystring with %2C as the array was flattened to a string
-  // Multi values must be appended individually to get the to-spec output
-  for (const [key, values] of Object.entries(
-    event.multiValueQueryStringParameters ?? {},
-  )) {
-    for (const value of values ?? []) {
-      searchParams.append(key, value);
-    }
+  let search: string;
+  if ('rawQueryString' in event) {
+    search = event.rawQueryString;
+  } else if ('queryStringParameters' in event) {
+    event.queryStringParameters;
+    search = normalizeQueryStringParams(
+      event.queryStringParameters,
+      event.multiValueQueryStringParameters,
+    ).toString();
+  } else {
+    throw new Error('Search params not parsable from event');
   }
+
+  const body = event.body ?? '';
 
   return {
-    method: event.httpMethod,
+    method: httpMethod,
     headers,
-    search: searchParams.toString(),
-    body,
-  };
-}
-
-function normalizeV2Event(event: APIGatewayProxyEventV2): HTTPGraphQLRequest {
-  const headers = normalizeHeaders(event.headers);
-  return {
-    method: event.requestContext.http.method,
-    headers,
-    search: event.rawQueryString,
-    body: parseBody(event.body, headers.get('content-type')),
+    search,
+    body: parseBody(body, headers.get('content-type')),
   };
 }
 
@@ -165,20 +144,31 @@ function parseBody(
   return '';
 }
 
-function normalizeHeaders(headers: APIGatewayProxyEventHeaders): HeaderMap {
+function normalizeHeaders(headers: IncomingEvent['headers']): HeaderMap {
   const headerMap = new HeaderMap();
-  for (const [key, value] of Object.entries(headers)) {
+  for (const [key, value] of Object.entries(headers ?? {})) {
     headerMap.set(key, value ?? '');
   }
   return headerMap;
 }
 
 function normalizeQueryStringParams(
-  queryStringParams: APIGatewayProxyEventQueryStringParameters | null,
-): Record<string, string> {
-  const queryStringRecord: Record<string, string> = {};
+  queryStringParams: Record<string, string | undefined> | null | undefined,
+  multiValueQueryStringParameters:
+    | Record<string, string[] | undefined>
+    | null
+    | undefined,
+): URLSearchParams {
+  const params = new URLSearchParams();
   for (const [key, value] of Object.entries(queryStringParams ?? {})) {
-    queryStringRecord[key] = value ?? '';
+    params.append(key, value ?? '');
   }
-  return queryStringRecord;
+  for (const [key, value] of Object.entries(
+    multiValueQueryStringParameters ?? {},
+  )) {
+    for (const v of value ?? []) {
+      params.append(key, v);
+    }
+  }
+  return params;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,6 @@ export type IncomingEvent =
   | APIGatewayProxyEventV2
   | ALBEvent;
 
-export type GatewayEvent = IncomingEvent;
-
 export interface LambdaContextFunctionArgument {
   event: IncomingEvent;
   context: Context;

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,13 +36,10 @@ export interface LambdaHandlerOptions<TContext extends BaseContext> {
   context?: ContextFunction<[LambdaContextFunctionArgument], TContext>;
 }
 
-export type HandlerResult = (
+export type HandlerResult =
   | APIGatewayProxyStructuredResultV2
   | APIGatewayProxyResult
-  | ALBResult
-) & {
-  statusCode: number;
-};
+  | ALBResult;
 
 type LambdaHandler = Handler<IncomingEvent, HandlerResult>;
 


### PR DESCRIPTION
Implements the ALB event type. Given that V2 is _very_ similar to ALB, I rewrote some of the normalization logic to condense parsing. Let me know your thoughts on this; after some research, it seems like there is no "official AWS supported way" of knowing exactly what event type has been passed to the Lambda. Given that, I figure we shouldn't try to parse type, and just look for the properties we need within the event object.

I also redid some of the type naming. Renamed `GatewayEvent` to `IncomingEvent` to better encapsulate ALB and lambda at edge and CloudFront functions in the future. Marked as a minor change as `GatewayEvent` is removed.