### PR TITLE
Add base64 encoding support. Refactored tests for coverage

### DIFF
--- a/.changeset/twenty-owls-march.md
+++ b/.changeset/twenty-owls-march.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/aws-lambda': patch
+---
+
+Added support for base64 encoding

--- a/src/__tests__/defineLambdaTestSuite.ts
+++ b/src/__tests__/defineLambdaTestSuite.ts
@@ -1,0 +1,53 @@
+import { ApolloServer, ApolloServerOptions, BaseContext } from '@apollo/server';
+import {
+  CreateServerForIntegrationTestsOptions,
+  defineIntegrationTestSuite,
+} from '@apollo/server-integration-testsuite';
+import type { Handler } from 'aws-lambda';
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { startServerAndCreateLambdaHandler } from '..';
+import { urlForHttpServer } from './mockServer';
+
+export function defineLambdaTestSuite<Event, Response>(
+  mockServerFactory: (
+    handler: Handler<Event, Response>,
+    shouldBase64Encode: boolean,
+  ) => (req: IncomingMessage, res: ServerResponse) => void,
+) {
+  for (const shouldBase64Encode of [true, false]) {
+    describe(`With base64 encoding ${
+      shouldBase64Encode ? 'enabled' : 'disabled'
+    }`, () => {
+      defineIntegrationTestSuite(async function (
+        serverOptions: ApolloServerOptions<BaseContext>,
+        testOptions?: CreateServerForIntegrationTestsOptions,
+      ) {
+        const httpServer = createServer();
+        const server = new ApolloServer({
+          ...serverOptions,
+        });
+
+        const handler = startServerAndCreateLambdaHandler(server, testOptions);
+
+        httpServer.addListener('request', mockServerFactory(handler as Handler<Event, Response>, shouldBase64Encode));
+
+        await new Promise<void>((resolve) => {
+          httpServer.listen({ port: 0 }, resolve);
+        });
+  
+        return {
+          server,
+          url: urlForHttpServer(httpServer),
+          async extraCleanup() {
+            await new Promise<void>((resolve) => {
+              httpServer.close(() => resolve());
+            });
+          },
+        };
+      }, {
+        serverIsStartedInBackground: true,
+        noIncrementalDelivery: true,
+      });
+    });
+  }
+}

--- a/src/__tests__/integrationALB.test.ts
+++ b/src/__tests__/integrationALB.test.ts
@@ -1,51 +1,6 @@
-import { ApolloServer, ApolloServerOptions, BaseContext } from '@apollo/server';
-import {
-  CreateServerForIntegrationTestsOptions,
-  defineIntegrationTestSuite,
-} from '@apollo/server-integration-testsuite';
-import type { ALBEvent, ALBResult, Handler } from 'aws-lambda';
-import { createServer } from 'http';
-import { startServerAndCreateLambdaHandler } from '..';
 import { createMockALBServer } from './mockALBServer';
-import { urlForHttpServer } from './mockServer';
+import { defineLambdaTestSuite } from './defineLambdaTestSuite';
 
 describe('lambdaHandlerALB', () => {
-  defineIntegrationTestSuite(
-    async function (
-      serverOptions: ApolloServerOptions<BaseContext>,
-      testOptions?: CreateServerForIntegrationTestsOptions,
-    ) {
-      const httpServer = createServer();
-      const server = new ApolloServer({
-        ...serverOptions,
-      });
-
-      const handler = testOptions
-        ? startServerAndCreateLambdaHandler(server, testOptions)
-        : startServerAndCreateLambdaHandler(server);
-
-      httpServer.addListener(
-        'request',
-        createMockALBServer(handler as Handler<ALBEvent, ALBResult>),
-      );
-
-      await new Promise<void>((resolve) => {
-        httpServer.listen({ port: 0 }, resolve);
-      });
-
-      return {
-        server,
-        url: urlForHttpServer(httpServer),
-        async extraCleanup() {
-          await new Promise<void>((resolve) => {
-            httpServer.close(() => resolve());
-          });
-        },
-      };
-    },
-    {
-      serverIsStartedInBackground: true,
-      noIncrementalDelivery: true,
-    },
-  );
+  defineLambdaTestSuite(createMockALBServer);
 });

--- a/src/__tests__/integrationV1.test.ts
+++ b/src/__tests__/integrationV1.test.ts
@@ -1,48 +1,6 @@
-import { ApolloServer, ApolloServerOptions, BaseContext } from '@apollo/server';
-import {
-  CreateServerForIntegrationTestsOptions,
-  defineIntegrationTestSuite,
-} from '@apollo/server-integration-testsuite';
-import type { Handler } from 'aws-lambda';
-import { createServer } from 'http';
-import { startServerAndCreateLambdaHandler } from '..';
+import { defineLambdaTestSuite } from './defineLambdaTestSuite';
 import { createMockV1Server } from './mockAPIGatewayV1Server';
-import { urlForHttpServer } from './mockServer';
 
 describe('lambdaHandlerV1', () => {
-  defineIntegrationTestSuite(
-    async function (
-      serverOptions: ApolloServerOptions<BaseContext>,
-      testOptions?: CreateServerForIntegrationTestsOptions,
-    ) {
-      const httpServer = createServer();
-      const server = new ApolloServer({
-        ...serverOptions,
-      });
-
-      const handler: Handler = testOptions
-        ? startServerAndCreateLambdaHandler(server, testOptions)
-        : startServerAndCreateLambdaHandler(server);
-
-      httpServer.addListener('request', createMockV1Server(handler));
-
-      await new Promise<void>((resolve) => {
-        httpServer.listen({ port: 0 }, resolve);
-      });
-
-      return {
-        server,
-        url: urlForHttpServer(httpServer),
-        async extraCleanup() {
-          await new Promise<void>((resolve) => {
-            httpServer.close(() => resolve());
-          });
-        },
-      };
-    },
-    {
-      serverIsStartedInBackground: true,
-      noIncrementalDelivery: true,
-    },
-  );
+  defineLambdaTestSuite(createMockV1Server)
 });

--- a/src/__tests__/integrationV2.test.ts
+++ b/src/__tests__/integrationV2.test.ts
@@ -1,47 +1,6 @@
-import { ApolloServer, ApolloServerOptions, BaseContext } from '@apollo/server';
-import {
-  CreateServerForIntegrationTestsOptions,
-  defineIntegrationTestSuite,
-} from '@apollo/server-integration-testsuite';
-import { createServer } from 'http';
-import { startServerAndCreateLambdaHandler } from '..';
+import { defineLambdaTestSuite } from './defineLambdaTestSuite';
 import { createMockV2Server } from './mockAPIGatewayV2Server';
-import { urlForHttpServer } from './mockServer';
 
 describe('lambdaHandlerV2', () => {
-  defineIntegrationTestSuite(
-    async function (
-      serverOptions: ApolloServerOptions<BaseContext>,
-      testOptions?: CreateServerForIntegrationTestsOptions,
-    ) {
-      const httpServer = createServer();
-      const server = new ApolloServer({
-        ...serverOptions,
-      });
-
-      const handler = testOptions
-        ? startServerAndCreateLambdaHandler(server, testOptions)
-        : startServerAndCreateLambdaHandler(server);
-
-      httpServer.addListener('request', createMockV2Server(handler));
-
-      await new Promise<void>((resolve) => {
-        httpServer.listen({ port: 0 }, resolve);
-      });
-
-      return {
-        server,
-        url: urlForHttpServer(httpServer),
-        async extraCleanup() {
-          await new Promise<void>((resolve) => {
-            httpServer.close(() => resolve());
-          });
-        },
-      };
-    },
-    {
-      serverIsStartedInBackground: true,
-      noIncrementalDelivery: true,
-    },
-  );
+  defineLambdaTestSuite(createMockV2Server);
 });

--- a/src/__tests__/mockALBServer.ts
+++ b/src/__tests__/mockALBServer.ts
@@ -3,44 +3,47 @@ import type { IncomingMessage } from 'http';
 import type { ALBEvent, ALBResult, Handler } from 'aws-lambda';
 import { createMockServer } from './mockServer';
 
-export function createMockALBServer(handler: Handler<ALBEvent, ALBResult>) {
-  return createMockServer(handler, albEventFromRequest);
+export function createMockALBServer(handler: Handler<ALBEvent, ALBResult>, shouldBase64Encode: boolean) {
+  return createMockServer(handler, albEventFromRequest(shouldBase64Encode));
 }
 
-function albEventFromRequest(req: IncomingMessage, body: string): ALBEvent {
-  const urlObject = url.parse(req.url || '', false);
-  const searchParams = new URLSearchParams(urlObject.search ?? '');
-
-  const multiValueQueryStringParameters: ALBEvent['multiValueQueryStringParameters'] =
-    {};
-
-  for (const [key] of searchParams.entries()) {
-    const all = searchParams.getAll(key);
-    if (all.length > 1) {
-      multiValueQueryStringParameters[key] = all;
+function albEventFromRequest(shouldBase64Encode: boolean) {
+  return function (req: IncomingMessage, body: string): ALBEvent {
+    const urlObject = url.parse(req.url || '', false);
+    const searchParams = new URLSearchParams(urlObject.search ?? '');
+  
+    const multiValueQueryStringParameters: ALBEvent['multiValueQueryStringParameters'] =
+      {};
+  
+    for (const [key] of searchParams.entries()) {
+      const all = searchParams.getAll(key);
+      if (all.length > 1) {
+        multiValueQueryStringParameters[key] = all;
+      }
     }
-  }
-
-  return {
-    requestContext: {
-      elb: {
-        targetGroupArn: '...',
+  
+    return {
+      requestContext: {
+        elb: {
+          targetGroupArn: '...',
+        },
       },
-    },
-    httpMethod: req.method ?? 'GET',
-    path: urlObject.pathname ?? '/',
-    queryStringParameters: Object.fromEntries(searchParams.entries()),
-    headers: Object.fromEntries(
-      Object.entries(req.headers).map(([name, value]) => {
-        if (Array.isArray(value)) {
-          return [name, value.join(',')];
-        } else {
-          return [name, value];
-        }
-      }),
-    ),
-    multiValueQueryStringParameters,
-    body,
-    isBase64Encoded: false,
-  };
+      httpMethod: req.method ?? 'GET',
+      path: urlObject.pathname ?? '/',
+      queryStringParameters: Object.fromEntries(searchParams.entries()),
+      headers: Object.fromEntries(
+        Object.entries(req.headers).map(([name, value]) => {
+          if (Array.isArray(value)) {
+            return [name, value.join(',')];
+          } else {
+            return [name, value];
+          }
+        }),
+      ),
+      multiValueQueryStringParameters,
+      body: shouldBase64Encode ? Buffer.from(body, 'utf8').toString('base64') : body,
+      isBase64Encoded: shouldBase64Encode,
+    };
+  }
 }
+

--- a/src/__tests__/mockAPIGatewayV1Server.ts
+++ b/src/__tests__/mockAPIGatewayV1Server.ts
@@ -9,44 +9,49 @@ import { createMockServer } from './mockServer';
 
 export function createMockV1Server(
   handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult>,
+  shouldBase64Encode: boolean,
 ) {
-  return createMockServer(handler, v1EventFromRequest);
+  return createMockServer(handler, v1EventFromRequest(shouldBase64Encode));
 }
 
-function v1EventFromRequest(
-  req: IncomingMessage,
-  body: string,
-): APIGatewayProxyEvent {
-  const urlObject = url.parse(req.url || '', false);
-  const searchParams = new URLSearchParams(urlObject.search ?? '');
-
-  const multiValueQueryStringParameters: Record<string, string[]> = {};
-  for (const [key] of searchParams.entries()) {
-    const all = searchParams.getAll(key);
-    if (all.length > 1) {
-      multiValueQueryStringParameters[key] = all;
+function v1EventFromRequest(shouldBase64Encode: boolean) {
+  return function (
+    req: IncomingMessage,
+    body: string,
+  ): APIGatewayProxyEvent {
+    const urlObject = url.parse(req.url || '', false);
+    const searchParams = new URLSearchParams(urlObject.search ?? '');
+  
+    const multiValueQueryStringParameters: Record<string, string[]> = {};
+    for (const [key] of searchParams.entries()) {
+      const all = searchParams.getAll(key);
+      if (all.length > 1) {
+        multiValueQueryStringParameters[key] = all;
+      }
     }
+  
+    // simplify the V1 event down to what our integration actually cares about
+    const event: Partial<APIGatewayProxyEvent> = {
+      // @ts-expect-error (version actually can exist on v1 events, this seems to be a typing error)
+      version: '1.0',
+      httpMethod: req.method!,
+      headers: Object.fromEntries(
+        Object.entries(req.headers).map(([name, value]) => {
+          if (Array.isArray(value)) {
+            return [name, value.join(',')];
+          } else {
+            return [name, value];
+          }
+        }),
+      ),
+      queryStringParameters: Object.fromEntries(searchParams.entries()),
+      body: shouldBase64Encode ? Buffer.from(body, 'utf8').toString('base64') : body,
+      isBase64Encoded: shouldBase64Encode,
+      multiValueQueryStringParameters,
+      multiValueHeaders: {},
+    };
+  
+    return event as APIGatewayProxyEvent;
   }
-
-  // simplify the V1 event down to what our integration actually cares about
-  const event: Partial<APIGatewayProxyEvent> = {
-    // @ts-expect-error (version actually can exist on v1 events, this seems to be a typing error)
-    version: '1.0',
-    httpMethod: req.method!,
-    headers: Object.fromEntries(
-      Object.entries(req.headers).map(([name, value]) => {
-        if (Array.isArray(value)) {
-          return [name, value.join(',')];
-        } else {
-          return [name, value];
-        }
-      }),
-    ),
-    queryStringParameters: Object.fromEntries(searchParams.entries()),
-    body,
-    multiValueQueryStringParameters,
-    multiValueHeaders: {},
-  };
-
-  return event as APIGatewayProxyEvent;
+  
 }

--- a/src/__tests__/mockAPIGatewayV2Server.ts
+++ b/src/__tests__/mockAPIGatewayV2Server.ts
@@ -9,48 +9,53 @@ import { createMockServer } from './mockServer';
 
 export function createMockV2Server(
   handler: Handler<APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2>,
+  shouldBase64Encode: boolean,
 ) {
-  return createMockServer(handler, v2EventFromRequest);
+  return createMockServer(handler, v2EventFromRequest(shouldBase64Encode));
 }
 
-function v2EventFromRequest(
-  req: IncomingMessage,
-  body: string,
-): APIGatewayProxyEventV2 {
-  const urlObject = url.parse(req.url || '', false);
-
-  // simplify the V2 event down to what our integration actually cares about,
-  // but keep it defined in terms of the original type so we know the fields
-  // we _are_ populating are correct.
-  type TestEventType = Partial<
-    Omit<APIGatewayProxyEventV2, 'requestContext'> & {
-      requestContext: Partial<
-        Omit<APIGatewayProxyEventV2['requestContext'], 'http'> & {
-          http: Partial<APIGatewayProxyEventV2['requestContext']['http']>;
-        }
-      >;
-    }
-  >;
-
-  const event: TestEventType = {
-    version: '2.0',
-    body,
-    rawQueryString: urlObject.search?.replace(/^\?/, '') ?? '',
-    headers: Object.fromEntries(
-      Object.entries(req.headers).map(([name, value]) => {
-        if (Array.isArray(value)) {
-          return [name, value.join(',')];
-        } else {
-          return [name, value];
-        }
-      }),
-    ),
-    requestContext: {
-      http: {
-        method: req.method!,
-        path: req.url!,
+function v2EventFromRequest(shouldBase64Encode: boolean){
+  return function (
+    req: IncomingMessage,
+    body: string,
+  ): APIGatewayProxyEventV2 {
+    const urlObject = url.parse(req.url || '', false);
+  
+    // simplify the V2 event down to what our integration actually cares about,
+    // but keep it defined in terms of the original type so we know the fields
+    // we _are_ populating are correct.
+    type TestEventType = Partial<
+      Omit<APIGatewayProxyEventV2, 'requestContext'> & {
+        requestContext: Partial<
+          Omit<APIGatewayProxyEventV2['requestContext'], 'http'> & {
+            http: Partial<APIGatewayProxyEventV2['requestContext']['http']>;
+          }
+        >;
+      }
+    >;
+  
+    const event: TestEventType = {
+      version: '2.0',
+      body: shouldBase64Encode ? Buffer.from(body, 'utf8').toString('base64') : body,
+      rawQueryString: urlObject.search?.replace(/^\?/, '') ?? '',
+      headers: Object.fromEntries(
+        Object.entries(req.headers).map(([name, value]) => {
+          if (Array.isArray(value)) {
+            return [name, value.join(',')];
+          } else {
+            return [name, value];
+          }
+        }),
+      ),
+      requestContext: {
+        http: {
+          method: req.method!,
+          path: req.url!,
+        },
       },
-    },
-  };
-  return event as APIGatewayProxyEventV2;
+      isBase64Encoded: shouldBase64Encode,
+    };
+    return event as APIGatewayProxyEventV2;
+  }
+  
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,20 +126,22 @@ function normalizeIncomingEvent(event: IncomingEvent): HTTPGraphQLRequest {
     method: httpMethod,
     headers,
     search,
-    body: parseBody(body, headers.get('content-type')),
+    body: parseBody(body, headers.get('content-type'), event.isBase64Encoded),
   };
 }
 
 function parseBody(
   body: string | null | undefined,
   contentType: string | undefined,
+  isBase64: boolean,
 ): object | string {
   if (body) {
+    const parsedBody = isBase64 ? Buffer.from(body, 'base64').toString('utf8') : body;
     if (contentType?.startsWith('application/json')) {
-      return JSON.parse(body);
+      return JSON.parse(parsedBody);
     }
     if (contentType?.startsWith('text/plain')) {
-      return body;
+      return parsedBody;
     }
   }
   return '';


### PR DESCRIPTION
Fixes #64 

Allows for lambda runtime to accept base64 encoded input data. In order to support this in testing I also spent the time to clean up the definitions as there was a lot of repeated code, and would be even more with base64 encoding on and off.