### PR TITLE
Bugfix, deduplicate querystring params

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,9 @@ function normalizeQueryStringParams(
     multiValueQueryStringParameters ?? {},
   )) {
     for (const v of value ?? []) {
-      params.append(key, v);
+      if (!params.has(key)) {
+        params.append(key, v);
+      }
     }
   }
   return params;


### PR DESCRIPTION
This library _merges_ `event.queryStringParameters` and `event.multiValueQueryStringParameters`. This means that if the same parameter is sent as a "normal" querystring and as multi value querystring (which they typically are), then we end up with duplicated search params, like 
```js
URLSearchParams { 'monkey' => 'ball', 'monkey' => 'ball' }
```

All fine and dandy until Apollo Server takes over and checks that a search param only exist **once** here: https://github.com/apollographql/apollo-server/blob/main/packages/server/src/runHttpQuery.ts#L35

This PR ensures that the params aren't duplicated.

On my setup, this manifests itself on AWS, and locally when doing an APQ query like this (APQ for `query { __typename }`):

```bash
curl --get http://localhost:5001/graphql \
  --header 'content-type: application/json' \
  --data-urlencode 'extensions={"persistedQuery":{"version":1,"sha256Hash":"ecf4edb46db40b5132295c0291d62fb65d6759a9eedfa4d5d612dd5ec54a6b38"}}'
  ```