### PR TITLE
Update CS:CI config

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,4 @@
 {
   "sandboxes": ["apollo-server-integration-aws-lambda-k6ismd"],
-  "node": "16",
-  "installCommand": "install-with-npm-8.5"
+  "node": "18"
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "//": "#use npx here to ensure that non-TS users triggering the postinstall script don't need to install TypeScript globally or in their project",
     "build": "npx -p typescript tsc --build tsconfig.build.json",
     "clean": "git clean -dfqX",
-    "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i",
     "postinstall": "npm run build",
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",


### PR DESCRIPTION
Remove an old workaround now that CS:CI supports `node@18`