### PR TITLE
Updated middleware execution to provide new functionality

### DIFF
--- a/.changeset/giant-rats-rhyme.md
+++ b/.changeset/giant-rats-rhyme.md
@@ -1,0 +1,66 @@
+---
+'@as-integrations/aws-lambda': minor
+---
+
+You can now opt to return a Lambda result object directly from the middleware. This will cancel the middleware chain, bypass GraphQL request processing, and immediately return the Lambda result.
+
+Example
+
+```ts
+export const handler = startServerAndCreateLambdaHandler(
+  server,
+  handlers.createAPIGatewayProxyEventV2RequestHandler(),
+  {
+    context: async () => {
+      return {};
+    },
+    middleware: [
+      async (event) => {
+        const psk = Buffer.from('SuperSecretPSK');
+        const token = Buffer.from(event.headers['X-Auth-Token']);
+        if (
+          psk.byteLength !== token.byteLength ||
+          crypto.timingSafeEqual(psk, token)
+        ) {
+          return {
+            statusCode: '403',
+            body: 'Forbidden',
+          };
+        }
+      },
+    ],
+  },
+);
+```
+
+In order to facilitate the resolvers making updates to the resultant lambda response, the server context can be used to pass data back to the result in the middleware.
+
+Example:
+
+```ts
+export const handler = startServerAndCreateLambdaHandler(
+  server,
+  handlers.createAPIGatewayProxyEventV2RequestHandler(),
+  {
+    context: async () => {
+      return {
+        foo: 'bar',
+      };
+    },
+    middleware: [
+      async () => {
+        return async (result, context) => {
+          if (!result.cookies) {
+            result.cookies = [];
+          }
+          if (context?.foo) {
+            reuslt.cookies.push(`foo=${context.foo}`);
+          }
+        };
+      },
+    ],
+  },
+);
+
+// Event will have `cookies: ['foo=bar']`
+```

--- a/.changeset/giant-rats-rhyme.md
+++ b/.changeset/giant-rats-rhyme.md
@@ -2,7 +2,7 @@
 '@as-integrations/aws-lambda': minor
 ---
 
-## Short circut middleware execution
+## Short circuit middleware execution
 
 You can now opt to return a Lambda result object directly from the middleware. This will cancel the middleware chain, bypass GraphQL request processing, and immediately return the Lambda result.
 

--- a/.changeset/giant-rats-rhyme.md
+++ b/.changeset/giant-rats-rhyme.md
@@ -34,37 +34,3 @@ export const handler = startServerAndCreateLambdaHandler(
   },
 );
 ```
-
-## Utilize context in middleware result
-
-In order to facilitate the resolvers making updates to the resultant lambda response, the server context can be used to pass data back to the result in the middleware.
-
-Example:
-
-```ts
-export const handler = startServerAndCreateLambdaHandler(
-  server,
-  handlers.createAPIGatewayProxyEventV2RequestHandler(),
-  {
-    context: async () => {
-      return {
-        foo: 'bar',
-      };
-    },
-    middleware: [
-      async () => {
-        return async (result, context) => {
-          if (!result.cookies) {
-            result.cookies = [];
-          }
-          if (context?.foo) {
-            reuslt.cookies.push(`foo=${context.foo}`);
-          }
-        };
-      },
-    ],
-  },
-);
-
-// Event will have `cookies: ['foo=bar']`
-```

--- a/.changeset/giant-rats-rhyme.md
+++ b/.changeset/giant-rats-rhyme.md
@@ -2,6 +2,8 @@
 '@as-integrations/aws-lambda': minor
 ---
 
+## Short circut middleware execution
+
 You can now opt to return a Lambda result object directly from the middleware. This will cancel the middleware chain, bypass GraphQL request processing, and immediately return the Lambda result.
 
 Example
@@ -32,6 +34,8 @@ export const handler = startServerAndCreateLambdaHandler(
   },
 );
 ```
+
+## Utilize context in middleware result
 
 In order to facilitate the resolvers making updates to the resultant lambda response, the server context can be used to pass data back to the result in the middleware.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import {
 // The GraphQL schema
 const typeDefs = `#graphql
   type Query {
-    hello: String
+    hello: String!
   }
 `;
 
@@ -42,6 +42,59 @@ const server = new ApolloServer({
 export default startServerAndCreateLambdaHandler(
   server,
   handlers.createAPIGatewayProxyEventV2RequestHandler(),
+);
+```
+
+## Context
+
+As with all Apollo Server 4 integrations, the context resolution is done in the integration. For the Lambda integration, it will look like the following:
+
+```ts
+import { ApolloServer } from '@apollo/server';
+import {
+  startServerAndCreateLambdaHandler,
+  handlers,
+} from '@as-integrations/aws-lambda';
+
+type ContextValue = {
+  isAuthenticated: boolean;
+}
+
+// The GraphQL schema
+const typeDefs = `#graphql
+  type Query {
+    hello: String!
+    isAuthenticated: Boolean!
+  }
+`;
+
+// Set up Apollo Server
+const server = new ApolloServer<ContextValue>({
+  typeDefs,
+  resolvers: {
+    Query: {
+      hello: () => 'world',
+      isAuthenticated: (root, args, context) => {
+        // For context typing to be valid one of the following must be implemented
+        //   1. `resolvers` defined inline in the server config (not particularly scalable, but works)
+        //   2. Add the type in the resolver function. ex. `(root, args, context: ContextValue)`
+        //   3. Propagate the type from an outside definition like GraphQL Codegen
+        return context.isAuthenticated
+      }
+    },
+  },
+});
+
+export default startServerAndCreateLambdaHandler(
+  server,
+  handlers.createAPIGatewayProxyEventV2RequestHandler({
+    context: async ({event}) => {
+      // Do some parsing on the event (parse JWT, cookie, auth header, etc.)
+      return {
+        isAuthenticated: true
+      }
+    }
+  }),
 );
 ```
 
@@ -82,6 +135,8 @@ export default startServerAndCreateLambdaHandler(
   },
 );
 ```
+
+### Middleware Typing
 
 If you want to define strictly typed middleware outside of the middleware array, the easiest way would be to extract your request handler into a variable and utilize the `typeof` keyword from Typescript. You could also manually use the `RequestHandler` type and fill in the event and result values yourself.
 
@@ -129,6 +184,47 @@ export default startServerAndCreateLambdaHandler(server, requestHandler, {
     // not sufficiently overlap, meaning it is your responsibility
     // to keep the event types in sync, but the compiler may help
     otherMiddleware,
+  ],
+});
+```
+
+### Middleware Short Circuit
+
+In some situations, a middleware function might require the execution end before reaching Apollo Server. This might be a global auth guard or session token lookup.
+
+To achieve this, the request middleware function accepts `ResultType` or `Promise<ResultType>` as a return type. Should middleware resolve to such a value, that result is returned and no further execution occurs.
+
+```typescript
+import {
+  startServerAndCreateLambdaHandler,
+  middleware,
+  handlers,
+} from '@as-integrations/aws-lambda';
+import type {
+  APIGatewayProxyEventV2,
+  APIGatewayProxyStructuredResultV2,
+} from 'aws-lambda';
+import { server } from './server';
+
+const requestHandler = handlers.createAPIGatewayProxyEventV2RequestHandler();
+
+// Utilizing typeof
+const sessionMiddleware: middleware.MiddlewareFn<typeof requestHandler> = (
+  event,
+) => {
+  // ... check session
+  if (!event.headers['X-Session-Key']) {
+    // If header doesn't exist, return early
+    return {
+      statusCode: 401
+      body: 'Unauthorized'
+    }
+  }
+};
+
+export default startServerAndCreateLambdaHandler(server, requestHandler, {
+  middleware: [
+    sessionMiddleware,
   ],
 });
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import {
 
 type ContextValue = {
   isAuthenticated: boolean;
-}
+};
 
 // The GraphQL schema
 const typeDefs = `#graphql
@@ -79,8 +79,8 @@ const server = new ApolloServer<ContextValue>({
         //   1. `resolvers` defined inline in the server config (not particularly scalable, but works)
         //   2. Add the type in the resolver function. ex. `(root, args, context: ContextValue)`
         //   3. Propagate the type from an outside definition like GraphQL Codegen
-        return context.isAuthenticated
-      }
+        return context.isAuthenticated;
+      },
     },
   },
 });
@@ -88,12 +88,12 @@ const server = new ApolloServer<ContextValue>({
 export default startServerAndCreateLambdaHandler(
   server,
   handlers.createAPIGatewayProxyEventV2RequestHandler({
-    context: async ({event}) => {
+    context: async ({ event }) => {
       // Do some parsing on the event (parse JWT, cookie, auth header, etc.)
       return {
-        isAuthenticated: true
-      }
-    }
+        isAuthenticated: true,
+      };
+    },
   }),
 );
 ```

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -13,3 +13,4 @@ vendia
 withrequired
 typeof
 instanceof
+codegen

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,7 +1,5 @@
 import { ApolloServer } from '@apollo/server';
-import type {
-  APIGatewayProxyEventV2,
-} from 'aws-lambda';
+import type { APIGatewayProxyEventV2 } from 'aws-lambda';
 import { handlers, startServerAndCreateLambdaHandler } from '..';
 import gql from 'graphql-tag';
 import { type DocumentNode, print } from 'graphql';

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -105,8 +105,7 @@ describe('Request mutation', () => {
           };
         },
         middleware: [
-          async (event) => {
-            event.headers[''];
+          async () => {
             return {
               statusCode: 418,
             };

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,7 +1,6 @@
 import { ApolloServer } from '@apollo/server';
 import type {
   APIGatewayProxyEventV2,
-  APIGatewayProxyStructuredResultV2,
 } from 'aws-lambda';
 import { handlers, startServerAndCreateLambdaHandler } from '..';
 import gql from 'graphql-tag';
@@ -151,41 +150,5 @@ describe('Response mutation', () => {
     );
     const result = await lambdaHandler(event, {} as any, () => {})!;
     expect(result.cookies).toContain(cookieValue);
-  });
-  it('is allowed to access updated context in result middleware', async () => {
-    const event = createEvent(gql`
-      mutation {
-        mutateContext
-      }
-    `);
-    const lambdaHandler = startServerAndCreateLambdaHandler<
-      handlers.RequestHandler<
-        APIGatewayProxyEventV2,
-        APIGatewayProxyStructuredResultV2
-      >,
-      {
-        foo: string | null;
-      }
-    >(server, handlers.createAPIGatewayProxyEventV2RequestHandler(), {
-      context: async () => {
-        return {
-          foo: 'bar',
-        };
-      },
-      middleware: [
-        async () => {
-          return async (result, context) => {
-            if (!result.cookies) {
-              result.cookies = [];
-            }
-            if (context?.foo) {
-              result.cookies.push(`foo=${context?.foo ?? 'UNKNOWN'}`);
-            }
-          };
-        },
-      ],
-    });
-    const result = await lambdaHandler(event, {} as any, () => {})!;
-    expect(result.cookies).toContain(`foo=bar`);
   });
 });

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,34 +1,56 @@
 import { ApolloServer } from '@apollo/server';
-import type { APIGatewayProxyEventV2 } from 'aws-lambda';
+import type {
+  APIGatewayProxyEventV2,
+  APIGatewayProxyStructuredResultV2,
+} from 'aws-lambda';
 import { handlers, startServerAndCreateLambdaHandler } from '..';
+import gql from 'graphql-tag';
+import { type DocumentNode, print } from 'graphql';
 
-const event: APIGatewayProxyEventV2 = {
-  version: '2',
-  headers: {
-    'content-type': 'application/json',
-  },
-  isBase64Encoded: false,
-  rawQueryString: '',
-  requestContext: {
-    http: {
-      method: 'POST',
+function createEvent(doc: DocumentNode): APIGatewayProxyEventV2 {
+  return {
+    version: '2',
+    headers: {
+      'content-type': 'application/json',
     },
-    // Other requestContext properties omitted for brevity
-  } as any,
-  rawPath: '/',
-  routeKey: '/',
-  body: '{"operationName": null, "variables": null, "query": "{ hello }"}',
-};
+    isBase64Encoded: false,
+    rawQueryString: '',
+    requestContext: {
+      http: {
+        method: 'POST',
+      },
+      // Other requestContext properties omitted for brevity
+    } as any,
+    rawPath: '/',
+    routeKey: '/',
+    body: JSON.stringify({
+      query: print(doc),
+    }),
+  };
+}
 
 const typeDefs = `#graphql
   type Query {
     hello: String
+  }
+  type Mutation {
+    mutateContext: String
   }
 `;
 
 const resolvers = {
   Query: {
     hello: () => 'world',
+  },
+  Mutation: {
+    mutateContext: async (
+      _root: any,
+      _args: any,
+      context: { foo: string | null },
+    ) => {
+      context.foo = 'bar';
+      return 'ok';
+    },
   },
 };
 
@@ -39,6 +61,11 @@ const server = new ApolloServer({
 
 describe('Request mutation', () => {
   it('updates incoming event headers', async () => {
+    const event = createEvent(gql`
+      query {
+        hello
+      }
+    `);
     const headerAdditions = {
       'x-injected-header': 'foo',
     };
@@ -46,6 +73,11 @@ describe('Request mutation', () => {
       server,
       handlers.createAPIGatewayProxyEventV2RequestHandler(),
       {
+        context: async () => {
+          return {
+            foo: null,
+          };
+        },
         middleware: [
           async (event) => {
             Object.assign(event.headers, headerAdditions);
@@ -58,15 +90,53 @@ describe('Request mutation', () => {
       expect(event.headers[key]).toBe(value);
     }
   });
+  it('returns early if middleware returns a result', async () => {
+    const event = createEvent(gql`
+      query {
+        hello
+      }
+    `);
+    const lambdaHandler = startServerAndCreateLambdaHandler(
+      server,
+      handlers.createAPIGatewayProxyEventV2RequestHandler(),
+      {
+        context: async () => {
+          return {
+            foo: null,
+          };
+        },
+        middleware: [
+          async (event) => {
+            event.headers[''];
+            return {
+              statusCode: 418,
+            };
+          },
+        ],
+      },
+    );
+    const result = await lambdaHandler(event, {} as any, () => {})!;
+    expect(result.statusCode).toBe(418);
+  });
 });
 
 describe('Response mutation', () => {
   it('adds cookie values to emitted result', async () => {
+    const event = createEvent(gql`
+      query {
+        hello
+      }
+    `);
     const cookieValue = 'foo=bar';
     const lambdaHandler = startServerAndCreateLambdaHandler(
       server,
       handlers.createAPIGatewayProxyEventV2RequestHandler(),
       {
+        context: async () => {
+          return {
+            foo: null,
+          };
+        },
         middleware: [
           async () => {
             return async (result) => {
@@ -81,5 +151,41 @@ describe('Response mutation', () => {
     );
     const result = await lambdaHandler(event, {} as any, () => {})!;
     expect(result.cookies).toContain(cookieValue);
+  });
+  it('is allowed to access updated context in result middleware', async () => {
+    const event = createEvent(gql`
+      mutation {
+        mutateContext
+      }
+    `);
+    const lambdaHandler = startServerAndCreateLambdaHandler<
+      handlers.RequestHandler<
+        APIGatewayProxyEventV2,
+        APIGatewayProxyStructuredResultV2
+      >,
+      {
+        foo: string | null;
+      }
+    >(server, handlers.createAPIGatewayProxyEventV2RequestHandler(), {
+      context: async () => {
+        return {
+          foo: 'bar',
+        };
+      },
+      middleware: [
+        async () => {
+          return async (result, context) => {
+            if (!result.cookies) {
+              result.cookies = [];
+            }
+            if (context?.foo) {
+              result.cookies.push(`foo=${context?.foo ?? 'UNKNOWN'}`);
+            }
+          };
+        },
+      ],
+    });
+    const result = await lambdaHandler(event, {} as any, () => {})!;
+    expect(result.cookies).toContain(`foo=bar`);
   });
 });

--- a/src/lambdaHandler.ts
+++ b/src/lambdaHandler.ts
@@ -84,7 +84,7 @@ export function startServerAndCreateLambdaHandler<
         ) {
           return middlewareReturnValue;
         }
-        // If the middleware returns a value, we assume it's a result middleware
+        // If the middleware returns a function, we assume it's a result callback
         if (middlewareReturnValue) {
           resultMiddlewareFns.push(middlewareReturnValue);
         }

--- a/src/lambdaHandler.ts
+++ b/src/lambdaHandler.ts
@@ -71,9 +71,8 @@ export function startServerAndCreateLambdaHandler<
   > = options?.context ?? defaultContext;
 
   return async function (event, context) {
-    const resultMiddlewareFns: Array<
-      LambdaResponse<RequestHandlerResult<RH>>
-    > = [];
+    const resultMiddlewareFns: Array<LambdaResponse<RequestHandlerResult<RH>>> =
+      [];
     try {
       for (const middlewareFn of options?.middleware ?? []) {
         const middlewareReturnValue = await middlewareFn(event);
@@ -98,7 +97,7 @@ export function startServerAndCreateLambdaHandler<
           return contextFunction({
             event,
             context,
-          })
+          });
         },
       });
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,21 @@
 import type { RequestHandler } from './request-handlers/_create';
 
-export type LambdaResponse<ResultType> = (result: ResultType) => Promise<void>;
+export type LambdaResponse<ResultType, ContextType = any> = (
+  result: ResultType,
+  /**
+   * GraphQL context can be accessed here
+   * @note will be null when middleware called during an error scenario
+   */
+  context: ContextType | null,
+) => Promise<void>;
 
-export type LambdaRequest<EventType, ResultType> = (
+export type LambdaRequest<EventType, ResultType, ContextType = any> = (
   event: EventType,
-) => Promise<LambdaResponse<ResultType> | void>;
+) => Promise<LambdaResponse<ResultType, ContextType> | ResultType | void>;
 
-export type MiddlewareFn<RH extends RequestHandler<any, any>> =
-  RH extends RequestHandler<infer EventType, infer ResultType>
-    ? LambdaRequest<EventType, ResultType>
-    : never;
+export type MiddlewareFn<
+  RH extends RequestHandler<any, any>,
+  ContextType = any,
+> = RH extends RequestHandler<infer EventType, infer ResultType>
+  ? LambdaRequest<EventType, ResultType, ContextType>
+  : never;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,15 +1,12 @@
 import type { RequestHandler } from './request-handlers/_create';
 
-export type LambdaResponse<ResultType> = (
-  result: ResultType
-) => Promise<void>;
+export type LambdaResponse<ResultType> = (result: ResultType) => Promise<void>;
 
 export type LambdaRequest<EventType, ResultType> = (
   event: EventType,
 ) => Promise<LambdaResponse<ResultType> | ResultType | void>;
 
-export type MiddlewareFn<
-  RH extends RequestHandler<any, any>,
-> = RH extends RequestHandler<infer EventType, infer ResultType>
-  ? LambdaRequest<EventType, ResultType>
-  : never;
+export type MiddlewareFn<RH extends RequestHandler<any, any>> =
+  RH extends RequestHandler<infer EventType, infer ResultType>
+    ? LambdaRequest<EventType, ResultType>
+    : never;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,21 +1,15 @@
 import type { RequestHandler } from './request-handlers/_create';
 
-export type LambdaResponse<ResultType, ContextType = any> = (
-  result: ResultType,
-  /**
-   * GraphQL context can be accessed here
-   * @note will be null when middleware called during an error scenario
-   */
-  context: ContextType | null,
+export type LambdaResponse<ResultType> = (
+  result: ResultType
 ) => Promise<void>;
 
-export type LambdaRequest<EventType, ResultType, ContextType = any> = (
+export type LambdaRequest<EventType, ResultType> = (
   event: EventType,
-) => Promise<LambdaResponse<ResultType, ContextType> | ResultType | void>;
+) => Promise<LambdaResponse<ResultType> | ResultType | void>;
 
 export type MiddlewareFn<
   RH extends RequestHandler<any, any>,
-  ContextType = any,
 > = RH extends RequestHandler<infer EventType, infer ResultType>
-  ? LambdaRequest<EventType, ResultType, ContextType>
+  ? LambdaRequest<EventType, ResultType>
   : never;


### PR DESCRIPTION
## Short circut middleware execution

You can now opt to return a Lambda result object directly from the middleware. This will cancel the middleware chain, bypass GraphQL request processing, and immediately return the Lambda result.

Example

```ts
export const handler = startServerAndCreateLambdaHandler(
  server,
  handlers.createAPIGatewayProxyEventV2RequestHandler(),
  {
    context: async () => {
      return {};
    },
    middleware: [
      async (event) => {
        const psk = Buffer.from('SuperSecretPSK');
        const token = Buffer.from(event.headers['X-Auth-Token']);
        if (
          psk.byteLength !== token.byteLength ||
          crypto.timingSafeEqual(psk, token)
        ) {
          return {
            statusCode: '403',
            body: 'Forbidden',
          };
        }
      },
    ],
  },
);
```

Closes #102 

Closes #108 

Closes #97 

Closes #85 

Closes #84 
