### PR TITLE
Add small snippet to README to see where context needs to go

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,17 @@ const server = new ApolloServer({
   resolvers,
 });
 
+
+//Set up our options (optional)
+const options = {
+  middleware: [], //More on this below
+  context: {} // We can pass in our ApolloSever context here
+}
+
 export default startServerAndCreateLambdaHandler(
   server,
   handlers.createAPIGatewayProxyEventV2RequestHandler(),
+  options
 );
 ```
 


### PR DESCRIPTION
## Issue
As a user of the lib and new to Apollo i was following tutorials, when I got to Lambda integration i had no idea where to put my context object. 

## Fix
PR will just add a small example of how to interact with the third param of the startServer function. 
