### PR TITLE
Update README with context usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ import {
   startServerAndCreateLambdaHandler,
   handlers,
 } from '@as-integrations/aws-lambda';
+import { customMiddleware } from './custom-middleware';
 
 // The GraphQL schema
 const typeDefs = `#graphql
@@ -48,6 +49,7 @@ export default startServerAndCreateLambdaHandler(
         myCustomAuthContext: event.requestContext.authorizer,
       };
     },
+    middleware: [customMiddleware],
   },
 );
 ```
@@ -151,6 +153,7 @@ import {
   handlers,
 } from '@as-integrations/aws-lambda';
 import type { APIGatewayProxyEventV2WithLambdaAuthorizer } from 'aws-lambda';
+import { customMiddleware } from './custom-middleware';
 
 interface MyApolloContext {
   stage: string;
@@ -174,6 +177,7 @@ export const main = startServerAndCreateLambdaHandler(
         customAuth: event.requestContext.authorizer.lambda.myAuthorizerContext,
       };
     },
+    middleware: [customMiddleware],
   },
 );
 ```


### PR DESCRIPTION
Raised in https://github.com/apollo-server-integrations/apollo-server-integration-aws-lambda/issues/97

With Apollo V4's improved type support for context, it's not currently clear how to use it with this integration without a bit of digging, especially if you are using Typescript and want to make sure you are passing in the correct generics. 

With more codebases upgrading to Apollo V4 as a result of V3's end-of-life, it'll be likely more folks will be asking about this.