### PR TITLE
Drop support for Node v14, start testing against Node v20

### DIFF
--- a/.changeset/funny-chefs-shake.md
+++ b/.changeset/funny-chefs-shake.md
@@ -1,0 +1,5 @@
+---
+'@as-integrations/aws-lambda': major
+---
+
+Drop support for Node v14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ jobs:
       - run: npm run spell-check
 
 workflows:
-  version: 2
   Build:
     jobs:
       - NodeJS:
@@ -75,9 +74,9 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "14"
                 - "16"
                 - "18"
+                - "20"
       - Prettier
       - Lint
       - Spell Check

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - version-*
 
 jobs:
   release:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@changesets/changelog-github": "0.4.8",
         "@changesets/cli": "2.26.2",
         "@types/jest": "29.5.3",
-        "@types/node": "16.18.38",
+        "@types/node": "16.18.39",
         "@typescript-eslint/eslint-plugin": "5.62.0",
         "@typescript-eslint/parser": "5.62.0",
         "cspell": "6.31.2",
@@ -3002,9 +3002,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.38.tgz",
-      "integrity": "sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==",
+      "version": "16.18.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.39.tgz",
+      "integrity": "sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@changesets/changelog-github": "0.4.8",
         "@changesets/cli": "2.26.2",
         "@types/jest": "29.5.3",
-        "@types/node": "14.18.54",
+        "@types/node": "16.18.38",
         "@typescript-eslint/eslint-plugin": "5.62.0",
         "@typescript-eslint/parser": "5.62.0",
         "cspell": "6.31.2",
@@ -31,7 +31,7 @@
         "typescript": "5.1.6"
       },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=16.0"
       },
       "peerDependencies": {
         "@apollo/server": "^4.0.0"
@@ -3002,9 +3002,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.18.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.54.tgz",
-      "integrity": "sha512-uq7O52wvo2Lggsx1x21tKZgqkJpvwCseBBPtX/nKQfpVlEsLOb11zZ1CRsWUKvJF0+lzuA9jwvA7Pr2Wt7i3xw==",
+      "version": "16.18.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.38.tgz",
+      "integrity": "sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -8838,9 +8838,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.2",
     "@types/jest": "29.5.3",
-    "@types/node": "16.18.38",
+    "@types/node": "16.18.39",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
     "cspell": "6.31.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=14.0"
+    "node": ">=16.0"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
@@ -40,7 +40,7 @@
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.2",
     "@types/jest": "29.5.3",
-    "@types/node": "14.18.54",
+    "@types/node": "16.18.38",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
     "cspell": "6.31.2",

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,7 +21,7 @@
     // versions we support.
     {
       "matchPackageNames": ["@types/node"],
-      "allowedVersions": "14.x"
+      "allowedVersions": "16.x"
     },
   ],
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "target": "es2020",
+    "target": "es2021",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -18,7 +18,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es2020", "DOM"],
+    "lib": ["es2021", "DOM"],
     "types": ["node"],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
Fixes #99

Landing this to a `version-3` branch where we can land other breaking changes before releasing the next major.