### PR TITLE
fix: remove explicit node version from CodeSandbox CI config

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,3 @@
 {
-  "sandboxes": ["apollo-server-integration-aws-lambda-k6ismd"],
-  "node": "20.18.0"
+  "sandboxes": ["apollo-server-integration-aws-lambda-k6ismd"]
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
   "sandboxes": ["apollo-server-integration-aws-lambda-k6ismd"],
-  "node": "20"
+  "node": "20.18.0"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules/
 
 # Volta binaries (when using direnv/.envrc)
 .volta
+
+# Claude Code
+CLAUDE.md


### PR DESCRIPTION
CodeSandbox's Node 20 environment resolves to v20.12.2, which is below
the `>=20.18` requirement introduced by updated cspell versions. Their
config validator only accepts major integers, so `"22"` and `"20.18.0"`
are both rejected as invalid node versions.

Removing the `node` field lets CodeSandbox use its default Node version
instead of a pinned-but-too-old one.
