### PR TITLE
fix: set CodeSandbox CI to Node 22

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,4 @@
 {
-  "sandboxes": ["apollo-server-integration-aws-lambda-k6ismd"]
+  "sandboxes": ["apollo-server-integration-aws-lambda-k6ismd"],
+  "node": "22"
 }


### PR DESCRIPTION
Aligns with the project volta pin in package.json and meets the
>=20.18 engine requirement of updated cspell versions.