### PR TITLE
chore: drop Node 20 support, require Node >=22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "20"
                 - "22"
       - Prettier
       - Lint

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=16.0"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",


### PR DESCRIPTION
Node 20 reached end-of-life on April 30 2026. cspell v10 and other updated devDependencies now require Node >=22.18.0, making Node 20 incompatible with the dev toolchain.